### PR TITLE
Employee's Location Name Info Links User to Location Page

### DIFF
--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -23,7 +23,7 @@ export default ({ employee }) => {
         resolveResource(employee, employeeId, EmployeeRepository.get)
     }, [])
 
-//resolveResouece takes three arguments = property, parameter, getter
+    //resolveResouece takes three arguments = property, parameter, getter
 
     useEffect(() => {
         if (employeeId) {
@@ -37,8 +37,8 @@ export default ({ employee }) => {
             markLocation(resource.locations[0])
         }
     }, [resource])
-    
-    useEffect(()=>{
+
+    useEffect(() => {
         setCount(resource?.animalCaretakers?.length)
     })
 
@@ -65,10 +65,10 @@ export default ({ employee }) => {
                                 {resource.name}
                             </Link>
 
-                        <section>Caring for {animalCount} animals</section></>
+                                <section>Caring for {animalCount} animals</section></>
                     }
                 </h5>
-                
+
                 {
                     employeeId
                         ? <>
@@ -76,7 +76,15 @@ export default ({ employee }) => {
                                 Caring for {resource?.animals?.length} animals
                             </section>
                             <section>
-                                Working at {location?.location?.name} location
+                                Working at {
+                                    <Link className="card-link"
+                                        to={{
+                                            pathname: `/locations/${location?.location?.id}`
+                                        }}>
+                                        {location?.location?.name}
+                                    </Link>
+
+                                } location
                             </section>
                         </>
                         : ""


### PR DESCRIPTION
#### Description of Changes
1. Modified location name info in the employee detail card to work as a link to direct the user to that location's page.
​
#### Related Issue(s)
Fixes #24 

#### Steps to Review
1.  Provided that the user is logged in and viewing the employee list page, click on any employee name to view their individual details. The name of the location they work at should now appear as a link. When the user clicks on the link the page should immediately re-render to display that location's info page.