### PR TITLE
Able to assign owner to animal. Now shows the owners on the animal card

### DIFF
--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -91,7 +91,9 @@ export const Animal = ({ animal, syncAnimals,
 
                             <h6>Owners</h6>
                             <span className="small">
-                                Owned by unknown
+                                Owned by { myOwners.map((owner) => {
+                                    return owner?.user?.name
+                                }).join(" and ")}
                             </span>
 
                             {
@@ -99,7 +101,7 @@ export const Animal = ({ animal, syncAnimals,
                                     ? <select defaultValue=""
                                         name="owner"
                                         className="form-control small"
-                                        onChange={() => { }} >
+                                        onChange={(event) => { AnimalOwnerRepository.assignOwner(currentAnimal.id, parseInt(event.target.value)) }} >
                                         <option value="">
                                             Select {myOwners.length === 1 ? "another" : "an"} owner
                                         </option>


### PR DESCRIPTION
#### Description of Changes
1. If there is less than 2 owners to an animal, employee's can use the dropdown to assign an owner to that animal. The owners will now be displayed on the animal card. 
​
#### Related Issue(s)
fixes #12

#### Steps to Review
1. Go to the animals page using the navbar. Click on the expand for the animal card. There will a dropdown that appears in the card. Click on a name in the dropdown and it will assign an owner to the animal. The owner name should then appear on the animal's card. 