### PR TITLE
Customers Can Only View Their Animals in the Animal List

### DIFF
--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -159,7 +159,8 @@ export const Animal =
                                     ? <select defaultValue=""
                                         name="owner"
                                         className="form-control small"
-                                        onChange={(event) => { AnimalOwnerRepository.assignOwner(currentAnimal.id, parseInt(event.target.value)) }} >
+
+                                        onChange={(event) => { AnimalOwnerRepository.assignOwner(currentAnimal.id, parseInt(event.target.value)).then(() => {getPeople()}) }} >
                                         <option value="">
                                             Select {myOwners.length === 1 ? "another" : "an"} owner
                                         </option>

--- a/src/components/animals/AnimalList.js
+++ b/src/components/animals/AnimalList.js
@@ -22,7 +22,22 @@ export const AnimalListComponent = ({searchResults}) => {
     let { toggleDialog, modalIsOpen } = useModal("#dialog--animal")
 
     const syncAnimals = () => {
-        AnimalRepository.getAll().then(data => petAnimals(data))
+        AnimalRepository.getAll().then((data) => {
+            if (getCurrentUser().employee) {
+                petAnimals(data)
+
+            } else {
+                const customerAnimals = data.filter((animal) => {
+                    let currentUserOwner = animal.animalOwners.find(owner => owner.userId === getCurrentUser().id)
+                    if (currentUserOwner) {
+                        return animal
+                    }
+                }
+                )
+                petAnimals(customerAnimals)
+            }
+            
+        })
     }
 
     const [searchedAnimals, updatedAnimals] = useState([])


### PR DESCRIPTION
#### Description of Changes
1.  Added conditional logic to syncAnimals function in AnimalList to either set animal state with all animals for employee users to view or with a filtered array of animals that are only owned by the customer user that is currently logged in.
​
#### Related Issue(s)
Fixes #6 

#### Steps to Review
* Must test twice: once logged in as an employee and once logged in as a customer.
1.  Provided that the user is logged in as an employee, clicking on the Animals option in the NavBar will render the full list of all Animals in the database.
2. Provided that the user is logged in as a regular user (customer), clicking on the Animals option in the NavBar will render only animals that are owned by the current user. Note: if the user does not have any animalOwner objects associated with their userId, the AnimalList page will be blank.