### PR TITLE
AssignLocation Function Checks if The Employee Works at that Location Already

### DIFF
--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -78,6 +78,7 @@ export default ({ employee }) => {
             EmployeeRepository.assignLocation(locationObj)
             resolveResource(employee, employeeId, EmployeeRepository.get)
         }
+        resolveResource(employee, employeeId, EmployeeRepository.get)
     }
 
     return (

--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -22,8 +22,8 @@ export default ({ employee }) => {
 
     useEffect(() => {
         EmployeeRepository.getEmployeeLocations()
-        .then((res) => setEmployeeLocations(res))
-    },[])
+            .then((res) => setEmployeeLocations(res))
+    }, [])
 
     useEffect(() => {
         setAuth(getCurrentUser().employee)
@@ -73,7 +73,7 @@ export default ({ employee }) => {
             locationId: locationId,
         }
         const existingEmployeeLocation = employeeLocations.find(obj => obj.userId === parseInt(employeeId) && obj.locationId === locationId)
-        
+
         if (!existingEmployeeLocation) {
             EmployeeRepository.assignLocation(locationObj)
             resolveResource(employee, employeeId, EmployeeRepository.get)
@@ -127,17 +127,17 @@ export default ({ employee }) => {
                     employeeId
                         ? isEmployee
                             ? <><button className="btn--fireEmployee" onClick={() => { fireEmployee(resource.id) }}>Fire</button>
-                                <label for="location-select">Choose a location:</label>
                                 {resource?.locations?.length < 2
-                                    ? <select name="locations" id="location-select" onChange={(evt) => {
-                                        assignLocation(parseInt(evt.target.value))
+                                    ? <><label for="location-select">Choose a location:</label>
+                                        <select name="locations" id="location-select" onChange={(evt) => {
+                                            assignLocation(parseInt(evt.target.value))
                                         }} >
-                                        <option value="">--Please choose a location--</option>
-                                        {locations.map((loc) => (
-                                            <option key={loc.id} value={loc.id}>{loc.name}</option>
-                                        ))}
-                                    </select> :
-                                    ""}
+                                            <option value="">--Please choose a location--</option>
+                                            {locations.map((loc) => (
+                                                <option key={loc.id} value={loc.id}>{loc.name}</option>
+                                            ))}
+                                        </select></>
+                                    : ""}
                             </>
                             : ""
                         : ""

--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -18,6 +18,12 @@ export default ({ employee }) => {
     const history = useHistory()
     const [isEmployee, setAuth] = useState(false)
     const [locations, changeLocation] = useState([])
+    const [employeeLocations, setEmployeeLocations] = useState([])
+
+    useEffect(() => {
+        EmployeeRepository.getEmployeeLocations()
+        .then((res) => setEmployeeLocations(res))
+    },[])
 
     useEffect(() => {
         setAuth(getCurrentUser().employee)
@@ -66,8 +72,14 @@ export default ({ employee }) => {
             userId: parseInt(employeeId),
             locationId: locationId,
         }
-        EmployeeRepository.assignLocation(locationObj)
-        resolveResource(employee, employeeId, EmployeeRepository.get)
+        const existingEmployeeLocation = employeeLocations.find(obj => obj.userId === parseInt(employeeId) && obj.locationId === locationId)
+        
+        if (!existingEmployeeLocation) {
+            EmployeeRepository.assignLocation(locationObj)
+            resolveResource(employee, employeeId, EmployeeRepository.get)
+        } else {
+            window.alert("Employee is already assigned to this location")
+        }
     }
 
     return (
@@ -118,7 +130,9 @@ export default ({ employee }) => {
                             ? <><button className="btn--fireEmployee" onClick={() => { fireEmployee(resource.id) }}>Fire</button>
                                 <label for="location-select">Choose a location:</label>
                                 {resource?.locations?.length < 2
-                                    ? <select name="locations" id="location-select" onChange={(evt) => assignLocation(parseInt(evt.target.value))} >
+                                    ? <select name="locations" id="location-select" onChange={(evt) => {
+                                        assignLocation(parseInt(evt.target.value))
+                                        }} >
                                         <option value="">--Please choose a location--</option>
                                         {locations.map((loc) => (
                                             <option key={loc.id} value={loc.id}>{loc.name}</option>

--- a/src/components/employees/Employee.js
+++ b/src/components/employees/Employee.js
@@ -77,8 +77,6 @@ export default ({ employee }) => {
         if (!existingEmployeeLocation) {
             EmployeeRepository.assignLocation(locationObj)
             resolveResource(employee, employeeId, EmployeeRepository.get)
-        } else {
-            window.alert("Employee is already assigned to this location")
         }
     }
 

--- a/src/repositories/EmployeeRepository.js
+++ b/src/repositories/EmployeeRepository.js
@@ -35,4 +35,7 @@ export default {
     async assignLocation(rel) {
         return await fetchIt(`${Settings.remoteURL}/employeeLocations`, "POST", JSON.stringify(rel))
     },
+    async getEmployeeLocations() {
+        return await fetchIt(`${Settings.remoteURL}/employeeLocations`)
+    }
 }


### PR DESCRIPTION
#### Description of Changes
1.  Added conditional logic to the assignLocation function so that the new employeeLocation object will only POST if it does not already exist. Added an additional fetch function in the employee repository to support the logic.
​
#### Related Issue(s)
Fixes #31 

#### Steps to Review
1. Provided that the user is logged in and viewing an individual employee's page - attempt to assign the employee to the location that they are already currently assigned to using the select dropdown option. There should be no Network calls in the dev tools or any other response in the browser.
2. Selecting the alternate location option in the select will result in a new POST Network call and the card will re-render with updated JSX.