### PR TITLE
fixed indiviudal animal page to refresh the treatments when added

### DIFF
--- a/src/components/animals/Animal.js
+++ b/src/components/animals/Animal.js
@@ -192,7 +192,9 @@ export const Animal =
                                             .then(() => {
                                                 if (!animalId) {
                                                     syncAnimals()
-                                                } 
+                                                } else {
+                                                    resolveResource(animal, animalId, AnimalRepository.get)
+                                                }
                                             })
                                             .then(() => {
                                                 setDescription('')


### PR DESCRIPTION
#### Description of Changes
1. When on an individual animal page, you can now add a treatment that will automatically show on the treatment list. 
​
#### Related Issue(s)
Supports #33 

#### Steps to Review
1. In the navbar, click on the locations tab --> click on the location --> click on one of the animals name. This will bring you to a page where you can now add treatments. Add a treatment and it should appear in the treatment list below the submit button. 